### PR TITLE
Fix tag workflow

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           file: CHANGELOG.md
           pattern: ${{ github.ref_name }}
+          no-print-matched-heading: "true"
       - name: Publish the GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2024-07-25
+## [1.0.0] - 2024-07-30
 
 ### Added
 
 - Create the Catalyst Cloud API client library (#1)
+
+### Changed
+
+- Fix tag workflow (#2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ authors = [
 ]
 requires-python = ">=3.8"
 classifiers = [
-    "Development Status :: 5 - Stable",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: End Users/Desktop",
     "Intended Audience :: System Administrators",
@@ -47,7 +47,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Libraries",
-    "Typing :: Typed",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
* Ensure Trove classifiers defined in the package are valid.
* Do not include heading in release notes fetched from changelog in the GitHub Release.
* Update the release date for the package in the changelog.