### PR TITLE
Upgrade PDM to 2.18.1

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -17,7 +17,7 @@ jobs:
         uses: pdm-project/setup-pdm@v4
         with:
           python-version: "3.12"
-          version: "2.17.1"
+          version: "2.18.1"
       - name: Build source dist and wheels
         run: pdm build --verbose
       - name: Upload source dist and wheels to artifacts
@@ -48,7 +48,7 @@ jobs:
         uses: pdm-project/setup-pdm@v4
         with:
           python-version: "3.12"
-          version: "2.17.1"
+          version: "2.18.1"
       - name: Publish source dist and wheels to PyPI
         run: pdm publish --no-build --verbose
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         uses: pdm-project/setup-pdm@v4
         with:
           python-version: "3.12"
-          version: "2.17.1"
+          version: "2.18.1"
       - name: Build source dist and wheels
         run: pdm build --verbose
       - name: Upload source dist and wheels to artifacts

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,6 @@ repos:
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/pdm-project/pdm
-    rev: "2.17.1"
+    rev: "2.18.1"
     hooks:
       - id: pdm-lock-check

--- a/pdm.lock
+++ b/pdm.lock
@@ -371,7 +371,7 @@ files = [
 
 [[package]]
 name = "gnocchiclient"
-version = "7.0.8"
+version = "7.1.0"
 summary = "Python client library for Gnocchi"
 groups = ["default"]
 dependencies = [
@@ -381,12 +381,11 @@ dependencies = [
     "iso8601",
     "keystoneauth1>=2.0.0",
     "python-dateutil",
-    "six",
     "ujson",
 ]
 files = [
-    {file = "gnocchiclient-7.0.8-py2.py3-none-any.whl", hash = "sha256:9fae1e06d337834b1e27e73fb20c3c5440f8519191045a314f0a0481240be9f2"},
-    {file = "gnocchiclient-7.0.8.tar.gz", hash = "sha256:ecf4a1a6c394911ef0dd2f6fb20b38f795380d07e99b529e23d8ac583d22204b"},
+    {file = "gnocchiclient-7.1.0-py2.py3-none-any.whl", hash = "sha256:04e58c58e7b31674d93f6f514c5fcc227504fe7004d4098bafaf65dbb8acf3ab"},
+    {file = "gnocchiclient-7.1.0.tar.gz", hash = "sha256:eed4d63b06973d0130c60900ae42c774538b24e4d66de5c696fde9810b90fa82"},
 ]
 
 [[package]]


### PR DESCRIPTION
* Update PDM in the pre-commit hooks and CI pipelines to 2.18.1.
* Update the dependencies in `pdm.lock`:
    * `gnocchiclient`: `7.0.8` -> `7.1.0`